### PR TITLE
WIP: prevent user from loading any template when creating an issue

### DIFF
--- a/lib/redmine_templates/issues_controller_patch.rb
+++ b/lib/redmine_templates/issues_controller_patch.rb
@@ -13,9 +13,11 @@ class IssuesController < ApplicationController
     if params[:template_id] && params[:template_id].to_i.to_s == params[:template_id]
       permitted_params_override = params[:issue].present? ? params.require(:issue).to_unsafe_h : {}
       @issue_template = IssueTemplate.find_by_id(params[:template_id])
-      if @issue_template.present?
+      if @issue_template.present? && @issue_template.template_projects.pluck(:identifier).include?(params[:project_id])
         params[:issue] = @issue_template.attributes.slice(*Issue.attribute_names).merge(permitted_params_override)
         params[:issue][:project_id] = params[:project_id]
+      else
+        @issue_template = nil
       end
     end
   end


### PR DESCRIPTION
Il est possible de charger n'importe quel template lors de la création d'un ticket en le passant en query param (`/project-id/issues/new?template_id=1`).
Voici une proposition de fix.